### PR TITLE
Several fixes/modifications

### DIFF
--- a/LIBRETRO_CMDLINE
+++ b/LIBRETRO_CMDLINE
@@ -1,0 +1,20 @@
+LIBRETRO COMMANDLINE OPTIONS
+------------------------------------------------------------------------
+You can pass the ScummVM command line parameters to the libretro core by
+creating a text file containing the commands and then using that file as
+a rom file for the core.
+
+Example for Day of the Tentacle:
+1. Add "Day of the Tentacle" to ScummVM using the built-in ScummVM GUI.
+2. Make note of the gameid (in this case "tentacle")
+3. Create a text file containing the game id
+
+For example:
+"Day of the Tentacle.scummvm" --> inside the file is written a single line with
+the word "tentacle"
+
+Launch retroarch with the scummvm core and with this text file as the rom:
+./retroarch -L scummvm_libretro.so "/myroms/Day of the Tentacle.scummvm"
+
+The game will now launch directly instead of showing the ScummVM GUI.
+You can pass other ScummVM parameters in the text file besides the gameid.

--- a/backends/platform/libretro/build/Makefile
+++ b/backends/platform/libretro/build/Makefile
@@ -134,7 +134,7 @@ RM            = rm -f
 RM_REC        = rm -rf
 
 # Define build flags
-DEFINES       += -D__LIBRETRO__ -DNONSTANDARD_PORT -DUSE_RGB_COLOR -DUSE_OSD -DDISABLE_COMMAND_LINE -DDISABLE_TEXT_CONSOLE -DFRONTEND_SUPPORTS_RGB565 -DUSE_MT32EMU -Wno-multichar
+DEFINES       += -D__LIBRETRO__ -DNONSTANDARD_PORT -DUSE_RGB_COLOR -DUSE_OSD -DDISABLE_TEXT_CONSOLE -DFRONTEND_SUPPORTS_RGB565 -DUSE_MT32EMU -Wno-multichar
 INCLUDES      += -I$(srcdir)/$(retrodir) -I. -I$(srcdir) -I$(srcdir)/engines -I../libco
 DEPDIR        = .deps
 HAVE_GCC3     = true


### PR DESCRIPTION
Fixed 16 bit mouse cursors in FM-towns games.

Added command line options and ability to launch games directly.
- this required a slight modification of the Makefile
- documentation is in LIBRETRO_CMDLINE

Modified default controls
- added variable mouse speed for analog controls
- start button skips cut scenes
- select opens the ScummVM menu
- swapped in game A and B buttons to better match standards in other games and RetroArch
