### PR TITLE
Fix handling of keyboard meta keys 

### DIFF
--- a/backends/platform/libretro/os.cpp
+++ b/backends/platform/libretro/os.cpp
@@ -991,7 +991,7 @@ public:
         ev.type = down ? Common::EVENT_KEYDOWN : Common::EVENT_KEYUP;
         ev.kbd.keycode = (Common::KeyCode)keycode;
         ev.kbd.flags = _keyflags;
-        ev.kbd.ascii = character & 0x7F;
+        ev.kbd.ascii = character;
         _events.push_back(ev);
     }
 


### PR DESCRIPTION
Fix handling of keyboard meta keys. Old stripping of character value to 8 bit caused meta keys (shift, ctrl and alt) to be converted to ASCII chars instead of meta keys.
