### PR TITLE
Add libretro includes path to INCLUDES

### DIFF
--- a/configure
+++ b/configure
@@ -4717,7 +4717,7 @@ docdir = $docdir
 
 $_config_mk_data
 
-INCLUDES += $INCLUDES
+INCLUDES += $INCLUDES -Ibackends/platform/libretro/libretro-common/include
 OBJS += $OBJS
 DEFINES += $DEFINES
 LDFLAGS += $LDFLAGS


### PR DESCRIPTION
Was finding `boolean` was missing in includes. Explicitly adding this fixed it. There is likely a better place for this.
