### PR TITLE
Revert "Get rid of this variable"

### DIFF
--- a/backends/fs/posix/posix-fs.cpp
+++ b/backends/fs/posix/posix-fs.cpp
@@ -167,6 +167,8 @@ Common::WriteStream *POSIXFilesystemNode::createWriteStream() {
 namespace Posix {
 
 bool assureDirectoryExists(const Common::String &dir, const char *prefix) {
+	struct stat sb;
+
 	// Check whether the prefix exists if one is supplied.
 	if (prefix)
    {


### PR DESCRIPTION
Compiles with the definition in there, or without it. So it's likely best to keep it in there.
