### PR TITLE
Add 1.8.1 version information

### DIFF
--- a/backends/platform/libretro/libretro.cpp
+++ b/backends/platform/libretro/libretro.cpp
@@ -95,7 +95,7 @@ unsigned retro_api_version(void)
 void retro_get_system_info(struct retro_system_info *info)
 {
    info->library_name = "scummvm";
-   info->library_version = "git";
+   info->library_version = "1.8.1";
    info->valid_extensions = "exe|scum";
    info->need_fullpath = true;
    info->block_extract = false;


### PR DESCRIPTION
Adds `1.8.1` in the version information for `retro_get_system_info()`.
