### PR TITLE
Add vorbis and zlib support for all builds

### DIFF
--- a/backends/platform/libretro/build/Makefile
+++ b/backends/platform/libretro/build/Makefile
@@ -1,5 +1,7 @@
 ##LIBRETRO
 DEBUG=0
+USE_ZLIB = 1
+USE_TREMOR = 1
 
 ifeq ($(platform),)
 platform = unix
@@ -100,11 +102,9 @@ else ifeq ($(platform), vita)
 
 else ifeq ($(platform), android-armv7)
    TARGET  := $(TARGET_NAME)_libretro_android.so
-   DEFINES += -fPIC -Wno-multichar -DUSE_VORBIS -DUSE_TREMOR -DUSE_ZLIB
+   DEFINES += -fPIC -Wno-multichar
    LDFLAGS += -shared -Wl,--version-script=../link.T -fPIC
    TOOLSET = arm-linux-androideabi-
-   USE_ZLIB = 1
-   USE_TREMOR = 1
 else ifneq (,$(findstring armv,$(platform)))
    TARGET := $(TARGET_NAME)_libretro.so
    SHARED := -shared -Wl,--no-undefined
@@ -210,7 +210,7 @@ OBJS +=  $(srcdir)/$(LIBRETROCOMMON_DIR)/file/retro_dirent.o \
 endif
 
 POSIX = 1
-DEFINES += -DFS_TYPE_POSIX
+DEFINES += -DFS_TYPE_POSIX -DUSE_VORBIS -DUSE_TREMOR -DUSE_ZLIB
 MODULE_DIRS += $(retrodir)
 
 BACKEND := libretro


### PR DESCRIPTION
Extend use of zlib and Tremor to all platforms. Zlib and Tremor was originally baked in for Android but should compile fine on others as well (tested on Linux so far).

This adds vorbis and zlip support for data files that have been compressed with ScummVM tools.
