### PR TITLE
Append a newline at the end of the command to load game

### DIFF
--- a/backends/platform/libretro/libretro.cpp
+++ b/backends/platform/libretro/libretro.cpp
@@ -160,7 +160,11 @@ void parse_command_params(char* cmdline)
   int j =0 ;
   int cmdlen = strlen(cmdline);
   bool quotes = false;
-    
+
+  // Append a new line to the end of the command to signify it's finished.
+  cmdline[cmdlen] = '\n';
+  cmdline[++cmdlen] = '\0';
+
   // parse command line into array of arguments
   for(int i=0; i<cmdlen; i++)
   {


### PR DESCRIPTION
Saw that when loading a file from RetroArch with ScummVM, the file needed to have a newline at the end of the game slug...

The following worked (\n is a new line):

```
atlantis\n
```

The following did not work:

```
atlantis
```

....Without the newline at the end.

This pull request appends a newline to the end of the command string so that ScummVM loads the game properly, with or without the file having the newline at the end.
