### PR TITLE
Add the .scummvm extension to valid list of extensions

### DIFF
--- a/backends/platform/libretro/libretro.cpp
+++ b/backends/platform/libretro/libretro.cpp
@@ -96,7 +96,7 @@ void retro_get_system_info(struct retro_system_info *info)
 {
    info->library_name = "scummvm";
    info->library_version = "1.8.1";
-   info->valid_extensions = "exe|scum";
+   info->valid_extensions = "exe|scum|scummvm";
    info->need_fullpath = true;
    info->block_extract = false;
 }


### PR DESCRIPTION
Add `scummvm` to the ScummVM extensions. This builds upon what @lollo78 found in https://github.com/libretro/RetroArch/issues/3092 .
