### PR TITLE
Update cmd_params length

### DIFF
--- a/backends/platform/libretro/libretro.cpp
+++ b/backends/platform/libretro/libretro.cpp
@@ -43,7 +43,7 @@ bool EMULATORexited;
 cothread_t mainThread;
 cothread_t emuThread;
 
-static char cmd_params[20][100];
+static char cmd_params[20][200];
 static char cmd_params_num;
 
 void retro_leave_thread(void)


### PR DESCRIPTION
Attempt 2 to fix https://github.com/libretro/scummvm/issues/45.  Based on the error, it looks like paths to scummvm files are indeed clipping at exactly 100 characters.