### PR TITLE
libretro: Fix filesystem dialogs on windows

### DIFF
--- a/backends/platform/libretro/build/Makefile
+++ b/backends/platform/libretro/build/Makefile
@@ -175,8 +175,12 @@ DEPDIR        = .deps
 HAVE_GCC3     = true
 USE_RGB_COLOR = true
 
+# Compile platform specific parts (e.g. filesystem)
+ifeq ($(platform), win)
+WIN32 = 1
+else
 POSIX = 1
-DEFINES += -DFS_TYPE_POSIX
+endif
 
 BACKEND := libretro
 

--- a/backends/platform/libretro/os.cpp
+++ b/backends/platform/libretro/os.cpp
@@ -34,8 +34,13 @@
 #include "common/events.h"
 #include "audio/mixer_intern.h"
 
+#if defined(_WIN32)
+#include "backends/fs/windows/windows-fs-factory.h"
+#define FS_SYSTEM_FACTORY WindowsFilesystemFactory
+#else
 #include "backends/fs/posix/posix-fs-factory.h"
 #define FS_SYSTEM_FACTORY POSIXFilesystemFactory
+#endif
 
 #include "backends/timer/default/default-timer.h"
 #include "graphics/colormasks.h"


### PR DESCRIPTION
While testing scummvm on kodi's retroplayer I noticed that you can't "cd" out of the current working directory when trying to add a game.

ScummVM has a different FileSystemFactory implementation for Windows which the libretro core should use.