### PR TITLE
libretro: Ask frontend for default save directory

### DIFF
--- a/backends/platform/libretro/libretro.cpp
+++ b/backends/platform/libretro/libretro.cpp
@@ -205,6 +205,7 @@ void parse_command_params(char* cmdline)
 bool retro_load_game(const struct retro_game_info *game)
 {
    const char* sysdir;
+   const char* savedir;
 
    cmd_params_num = 1;
    strcpy(cmd_params[0],"scummvm\0");
@@ -262,6 +263,15 @@ bool retro_load_game(const struct retro_game_info *game)
       if (log_cb)
          log_cb(RETRO_LOG_WARN, "No System directory specified, using current directory.\n");
       retroSetSystemDir(".");
+   }
+
+   if(environ_cb(RETRO_ENVIRONMENT_GET_SAVE_DIRECTORY, &savedir))
+      retroSetSaveDir(savedir);
+   else
+   {
+      if (log_cb)
+         log_cb(RETRO_LOG_WARN, "No Save directory specified, using current directory.\n");
+      retroSetSaveDir(".");
    }
 
    if(!emuThread && !mainThread)

--- a/backends/platform/libretro/os.cpp
+++ b/backends/platform/libretro/os.cpp
@@ -245,6 +245,7 @@ static INLINE void copyRectToSurface(uint8_t *pixels, int out_pitch, const uint8
 }
 
 static Common::String s_systemDir;
+static Common::String s_saveDir;
 
 #ifdef FRONTEND_SUPPORTS_RGB565
 #define SURF_BPP 2
@@ -322,6 +323,9 @@ class OSystem_RETRO : public EventsBaseBackend, public PaletteManager {
 
       if(s_systemDir.empty())
          s_systemDir = ".";
+
+      if(s_saveDir.empty())
+         s_saveDir = ".";
    }
 
       virtual ~OSystem_RETRO()
@@ -336,7 +340,7 @@ class OSystem_RETRO : public EventsBaseBackend, public PaletteManager {
 
       virtual void initBackend()
       {
-         _savefileManager = new DefaultSaveFileManager();
+         _savefileManager = new DefaultSaveFileManager(s_saveDir);
 #ifdef FRONTEND_SUPPORTS_RGB565
          _overlay.create(RES_W, RES_H, Graphics::PixelFormat(2, 5, 6, 5, 0, 11, 5, 0, 0));
 #else
@@ -1020,6 +1024,11 @@ void retroPostQuit()
 void retroSetSystemDir(const char* aPath)
 {
    s_systemDir = Common::String(aPath ? aPath : ".");
+}
+
+void retroSetSaveDir(const char* aPath)
+{
+   s_saveDir = Common::String(aPath ? aPath : ".");
 }
 
 void retroKeyEvent(bool down, unsigned keycode, uint32_t character, uint16_t key_modifiers)

--- a/backends/platform/libretro/os.h
+++ b/backends/platform/libretro/os.h
@@ -49,6 +49,7 @@ void retroProcessMouse(retro_input_state_t aCallback);
 void retroPostQuit();
 
 void retroSetSystemDir(const char* aPath);
+void retroSetSaveDir(const char* aPath);
 
 void retroKeyEvent(bool down, unsigned keycode, uint32_t character, uint16_t key_modifiers);
 


### PR DESCRIPTION
Without changing the save path in the ingame menu, ScummVM tries to write savegames to the current working directory - and fails on Windows or OSX because the install directories are write protected.