### PR TITLE
Report git version with library_version

### DIFF
--- a/backends/platform/libretro/build/Makefile
+++ b/backends/platform/libretro/build/Makefile
@@ -27,6 +27,10 @@ ifeq ($(shell uname -a),)
 endif
 
 TARGET_NAME := scummvm
+GIT_VERSION := " $(shell git rev-parse --short HEAD || echo unknown)"
+ifneq ($(GIT_VERSION)," unknown")
+	CXXFLAGS += -DGIT_VERSION=\"$(GIT_VERSION)\"
+endif
 
 LD        = $(CXX)
 AR        = ar cru

--- a/backends/platform/libretro/libretro.cpp
+++ b/backends/platform/libretro/libretro.cpp
@@ -95,7 +95,10 @@ unsigned retro_api_version(void)
 void retro_get_system_info(struct retro_system_info *info)
 {
    info->library_name = "scummvm";
-   info->library_version = "1.8.1";
+#ifndef GIT_VERSION
+#define GIT_VERSION ""
+#endif
+   info->library_version = "1.8.1" GIT_VERSION;
    info->valid_extensions = "exe|scum|scummvm";
    info->need_fullpath = true;
    info->block_extract = false;

--- a/dists/android/jni/Android.mk
+++ b/dists/android/jni/Android.mk
@@ -2,6 +2,11 @@ LOCAL_PATH := $(call my-dir)
 
 include $(CLEAR_VARS)
 
+GIT_VERSION := " $(shell git rev-parse --short HEAD || echo unknown)"
+ifneq ($(GIT_VERSION)," unknown")
+	LOCAL_CXXFLAGS += -DGIT_VERSION=\"$(GIT_VERSION)\"
+endif
+
 APP_ABI := $(ABI)
 LOCAL_MODULE := scummvm
 LOCAL_SRC_FILES := ../libscummvm.so


### PR DESCRIPTION
This patch makes this core report the git version along with its library_version. This is important because otherwise it is impossible to replicate a build without extra knowledge, and things like Netplay that demand versions be the same can't be reliably known to work.