### PR TITLE
Fix build (missing mad.h)

### DIFF
--- a/backends/platform/libretro/build/Makefile.common
+++ b/backends/platform/libretro/build/Makefile.common
@@ -140,6 +140,7 @@ endif
 
 ifeq ($(USE_MAD), 1)
 DEFINES += -DUSE_MAD -DFPM_DEFAULT
+INCLUDES += -I$(DEPS_DIR)/libmad
 OBJS +=  $(DEPS_DIR)/libmad/bit.o \
 			$(DEPS_DIR)/libmad/decoder.o \
 			$(DEPS_DIR)/libmad/frame.o \


### PR DESCRIPTION
Missing include directory in a76496b79f05d4c67630bce000ea1b14f6751a81.

Fixes: https://github.com/libretro/scummvm/issues/56