### PR TITLE
travis: Use build-long.sh for Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,4 +33,4 @@ script:
   - cd ~/
   - git clone --depth=50 https://github.com/libretro/libretro-super
   - cd libretro-super/travis
-  - ./build.sh
+  - ./build-long.sh


### PR DESCRIPTION
Travis was killing the process as the log got too long.