### PR TITLE
Fix critical timing bug

### DIFF
--- a/backends/platform/libretro/os.cpp
+++ b/backends/platform/libretro/os.cpp
@@ -603,18 +603,15 @@ class OSystem_RETRO : public EventsBaseBackend, public PaletteManager {
          _mousePaletteEnabled = true;
       }
 
-      bool retroCheckThread(uint32 offset = 0)
+      void retroCheckThread(void)
       {
-         if(_threadExitTime <= (getMillis() + offset))
+         if(_threadExitTime <= getMillis())
          {
             extern void retro_leave_thread();
             retro_leave_thread();
 
             _threadExitTime = getMillis() + 10;
-            return true;
          }
-
-         return false;
       }
 
       virtual bool pollEvent(Common::Event &event)
@@ -652,8 +649,13 @@ class OSystem_RETRO : public EventsBaseBackend, public PaletteManager {
 
       virtual void delayMillis(uint msecs)
       {
-         if(!retroCheckThread(msecs))
-            retro_sleep(msecs);
+			// Implement 'non-blocking' sleep...
+			uint32 current_time = getMillis();
+			while(getMillis() < current_time + msecs)
+			{
+				retro_sleep(1);
+				retroCheckThread();
+			}
       }
 
 


### PR DESCRIPTION
While investigating issue #105 I discovered a severe bug in the core...

Essentially, (almost) every ScummVM game engine uses a delayMillis() function to ensure correct timing. This is used everywhere for everything, but here's an example: if a video cutscene is meant to run at 24fps, delayMillis() is used to insert a 41ms 'sleep' between frames, making it run at the correct speed.

The current core implementation of the delayMillis() function doesn't work at all. It pretty much returns immediately, so every timed process runs flat out. Most of the time the bug is not immediately obvious (the breakage is silent/internal), but in a number of cases it makes games unplayable. For example:

- Discworld 2: Cutscenes are broken (Issue #105)

- The Bizarre Adventures of Woodruff and the Schnibble of Azimuth: Cutscenes/animations are broken (Issue #97)

- Goblins 3: Cutscenes/animations are broken

- Nippon Safes Inc: Everything runs at hyperspeed

There are probably many, many more (I haven't tested every game, but a quick scan of the code shows too many examples of potential breakage to mention...)

This pull request just fixes the 'delayMillis()' function, thus fixing all affected games.

(It goes without saying that this should close issues #105 and #97)

@thatman84 - I'm afraid that once this is merged, your master compatibility list will need some updates! Sorry for the extra work...  :wink: 