### PR TITLE
Fix Dreamweb

### DIFF
--- a/backends/platform/libretro/os.cpp
+++ b/backends/platform/libretro/os.cpp
@@ -655,6 +655,10 @@ class OSystem_RETRO : public EventsBaseBackend, public PaletteManager {
 			{
 				retro_sleep(1);
 				retroCheckThread();
+				// ...and we also have to handle the timer manager here,
+				// since some engines (e.g. dreamweb) sit in a delayMillis()
+				// loop waiting for a timer callback...
+				((DefaultTimerManager*)_timerManager)->handler();
 			}
       }
 


### PR DESCRIPTION
This pull request adds ScummVM 'timer manager' handling to the 'delayMillis()' function mentioned in my last pull request (PR #110). It turns out that other ports run timer stuff in a separate thread - since we do it all in the main 'game' thread, we have to ensure that any 'sleep' loop polls for timer events.

I discovered this while debugging Dreamweb - the game basically sits in a 'delayMillis()' loop waiting for a timer callback (which never came). With this pull request, the game now works correctly (closing issue #79). Other games probably benefit from this too, but I haven't had time to investigate.