### PR TITLE
'Flight of the Amazon Queen' bug fixes

### DIFF
--- a/engines/queen/input.cpp
+++ b/engines/queen/input.cpp
@@ -120,6 +120,13 @@ void Input::delay(uint amount) {
 			case Common::EVENT_QUIT:
 				if (_cutawayRunning)
 					_cutawayQuit = true;
+#ifdef __LIBRETRO__
+				// Without this, Talk::defaultAnimation() gets stuck in
+				// an infinite loop if we try to quit the game while a
+				// dialogue is in progress...
+				if (_dialogueRunning)
+					_talkQuit = true;
+#endif
 				return;
 
 			default:

--- a/engines/queen/queen.cpp
+++ b/engines/queen/queen.cpp
@@ -50,7 +50,11 @@
 namespace Queen {
 
 QueenEngine::QueenEngine(OSystem *syst)
+#ifdef __LIBRETRO__
+	: Engine(syst), _gameStarted(false), _debugger(0), randomizer("queen") {
+#else
 	: Engine(syst), _debugger(0), randomizer("queen") {
+#endif
 }
 
 QueenEngine::~QueenEngine() {
@@ -173,7 +177,11 @@ void QueenEngine::update(bool checkPlayerInput) {
 }
 
 bool QueenEngine::canLoadOrSave() const {
+#ifdef __LIBRETRO__
+	return !_input->cutawayRunning() && !(_resource->isDemo() || _resource->isInterview()) && _gameStarted;
+#else
 	return !_input->cutawayRunning() && !(_resource->isDemo() || _resource->isInterview());
+#endif
 }
 
 bool QueenEngine::canLoadGameStateCurrently() {
@@ -368,6 +376,11 @@ Common::Error QueenEngine::run() {
 			_logic->currentRoom(_logic->newRoom());
 			_logic->changeRoom();
 			_display->fullscreen(false);
+#ifdef __LIBRETRO__
+			// From this point onwards it is safe to use the load/save
+			// menu, so consider game to be 'started'
+			_gameStarted = true;
+#endif
 			if (_logic->currentRoom() == _logic->newRoom()) {
 				_logic->newRoom(0);
 			}

--- a/engines/queen/queen.h
+++ b/engines/queen/queen.h
@@ -130,6 +130,10 @@ protected:
 	uint32 _lastSaveTime;
 	uint32 _lastUpdateTime;
 
+#ifdef __LIBRETRO__
+	bool _gameStarted;
+#endif
+
 	BamScene *_bam;
 	BankManager *_bankMan;
 	Command *_command;
@@ -142,6 +146,7 @@ protected:
 	Resource *_resource;
 	Sound *_sound;
 	Walk *_walk;
+
 };
 
 } // End of namespace Queen

--- a/engines/queen/sound.cpp
+++ b/engines/queen/sound.cpp
@@ -289,7 +289,13 @@ void PCSound::playSound(const char *base, bool isSpeech) {
 	}
 	strcat(name, ".SB");
 	if (isSpeech) {
+#ifdef __LIBRETRO__
+		// Add _vm->shouldQuit() check here, otherwise game gets stuck
+		// in an infinite loop if we try to quit while a sound is playing...
+		while (_mixer->isSoundHandleActive(_speechHandle) && !_vm->shouldQuit()) {
+#else
 		while (_mixer->isSoundHandleActive(_speechHandle)) {
+#endif
 			_vm->input()->delay(10);
 		}
 	} else {


### PR DESCRIPTION
The game engine for 'Flight of the Amazon Queen' has a couple of nasty bugs:

- It allows you to load a previous save before the game is properly initialised. At best, this leads to undefined behaviour. Most of the time it causes a segfault.

- If you try to close the core while a dialogue is in progress, it gets stuck in an infinite loop and hangs RetroArch indefinitely.

This pull request fixes these two issues. I've wrapped all the changes inside `#ifdef __LIBRETRO__` directives, so they can be easily identified if/when future upstream changes are merged.