### PR TITLE
Fix build on ARM platforms

### DIFF
--- a/backends/platform/libretro/build/Makefile
+++ b/backends/platform/libretro/build/Makefile
@@ -171,8 +171,8 @@ else ifeq ($(platform), android-armv7)
    HAVE_MT32EMU = 0
 else ifneq (,$(findstring armv,$(platform)))
    TARGET := $(TARGET_NAME)_libretro.so
-   SHARED := -shared -Wl,--no-undefined
    DEFINES += -fPIC -Wno-multichar -D_ARM_ASSEM_
+   LDFLAGS += -shared -Wl,--version-script=../link.T -fPIC
    CC = gcc
    USE_VORBIS = 0
    USE_THEORADEC = 0


### PR DESCRIPTION
The build of this core broke (unresolved symbols in the linking stage) in the recent commit 7f39a7fada991d59b902db3b7672ffa8c7f54e7d (cc @twinaphex)
The reason is that the changes in the commit incorrectly set `LD = $(CC)` in the Makefile, and this core uses `$(CXX)` instead.

I decided to remove the setting of `LD` altogether because it is already set earlier in the Makefile ([line 59](https://github.com/libretro/scummvm/blob/0acb5f837314cb14ad573d29f1589f644c4f1718/backends/platform/libretro/build/Makefile#L59)) so changing it is unnecessary outside of the msvc conditional. Let me know if you prefer instead to (correctly) re-set `LD = $(CXX)` in the conditional and I will update the PR accordingly. I tested this PR and it builds successfully.

Currently the core does not build on Raspberry Pi and I suspect it doesn't build on other non-msvc platforms as well, so I hope this can be merged soon.

Thanks!