### PR TITLE
fix-build: Do not force linker to `$(CC)` and do not force `CC` to `gcc` in `armv` platform check

### DIFF
--- a/backends/platform/libretro/build/Makefile
+++ b/backends/platform/libretro/build/Makefile
@@ -400,8 +400,6 @@ ifeq ($(STATIC_LINKING),1)
 else
 	LD = link.exe
 endif
-else
-	LD = $(CC)
 endif
 
 ifeq ($(platform), wiiu)

--- a/backends/platform/libretro/build/Makefile
+++ b/backends/platform/libretro/build/Makefile
@@ -173,7 +173,6 @@ else ifneq (,$(findstring armv,$(platform)))
    TARGET := $(TARGET_NAME)_libretro.so
    DEFINES += -fPIC -Wno-multichar -D_ARM_ASSEM_
    LDFLAGS += -shared -Wl,--version-script=../link.T -fPIC
-   CC = gcc
    USE_VORBIS = 0
    USE_THEORADEC = 0
    USE_TREMOR = 1


### PR DESCRIPTION
* This core has a mixed C/C++ codebase, therefore use the default `$(CXX)` as linker
* The `CC` variable might be set externally, e.g. by the buildbot

Currently the builds for Windows are broken after recent commit 7f39a7f
Currently the build for ARM7 Neon+HFP is broken

Tested on Linux64, ARM7 Neon+HFP and Windows64, all building fine now:

    SINGLE_CORE=scummvm CORE=scummvm ./libretro-buildbot-recipe.sh recipes/linux/cores-linux-arm7neonhf
    SINGLE_CORE=scummvm CORE=scummvm ./libretro-buildbot-recipe.sh recipes/linux/cores-linux-x64-generic
    SINGLE_CORE=scummvm CORE=scummvm ./libretro-buildbot-recipe.sh recipes/windows/cores-windows-x64_seh-generic
