### PR TITLE
fix-quit: Send `QUIT` events directly to the ScummVM event manager

### DIFF
--- a/backends/platform/libretro/os.cpp
+++ b/backends/platform/libretro/os.cpp
@@ -1258,7 +1258,7 @@ class OSystem_RETRO : public EventsBaseBackend, public PaletteManager {
       {
          Common::Event ev;
          ev.type = Common::EVENT_QUIT;
-         _events.push_back(ev);
+         ((OSystem_RETRO*)g_system)->getEventManager()->pushEvent(ev);
       }
 };
 


### PR DESCRIPTION
If a game is closed from RetroArch, e.g. using the exit combo on gamepad or using the Close Content functionality from the menu, at random times the system locks-up and RetroArch needs to be killed manually.

Sending `QUIT` events directly to the ScummVM event manager instead of using the `_events` queue as with keyboard/mouse events ensures that ScummVM gracefully closes every time.

This PR was tested to build on RPI (ARM), Windows and Linux.
This PR has been tested since Nov 2018 by RetroPie users, including myself.

Ref: #129 
Fixes #116, Closes #129