### PR TITLE
Link with g++ on Linux

### DIFF
--- a/backends/platform/libretro/build/Makefile
+++ b/backends/platform/libretro/build/Makefile
@@ -401,7 +401,7 @@ else
 	LD = link.exe
 endif
 else
-	LD = $(CC)
+	LD = $(CXX)
 endif
 
 ifeq ($(platform), wiiu)


### PR DESCRIPTION
Currently the core can't be loaded with gdb on Linux due to undefined symbols:
```
$ ldd -r scummvm_libretro.so:
undefined symbol: _ZTVN10__cxxabiv117__class_type_infoE (./scummvm_libretro.so)
```

@twinaphex The issue got introduced with https://github.com/libretro/scummvm/commit/7f39a7fada991d59b902db3b7672ffa8c7f54e7d#diff-87e142c543b2e9c8f781712f5a761365R424.

I've compile tested linux only.