### PR TITLE
fix-build-ios: Use correct `CC` compiler for ios platforms

### DIFF
--- a/backends/platform/libretro/build/Makefile
+++ b/backends/platform/libretro/build/Makefile
@@ -87,11 +87,14 @@ ifeq ($(IOSSDK),)
    IOSSDK := $(shell xcodebuild -version -sdk iphoneos Path)
 endif
 
+   CC       = clang -arch armv7 -isysroot $(IOSSDK) -marm
    CXX      = clang++ -arch armv7 -isysroot $(IOSSDK) -marm
 
 ifeq ($(platform),ios9)
+	CC      += -miphoneos-version-min=8.0
 	CXX     += -miphoneos-version-min=8.0
 else
+	CC      += -miphoneos-version-min=5.0
 	CXX     += -miphoneos-version-min=5.0
 endif
 


### PR DESCRIPTION
After checking the recent buildbot output, I just realised there are missing `CC` definitions for ios/ios9 platforms. Can you please merge this too @twinaphex? Sorry to bother and thanks in advance! Should fix the builds for ios/ios9 hopefully.

Note: I can't test this PR myself (no build env for these platforms), however I compared the change to other libretro Makefiles that build for ios/ios9 and should be fine.

Ref:
<retrobot> scummvm: [status: fail] [recipes/apple/cores-ios-generic] LOG: http://p.0bl.net/86233 Last good build: N/A
<retrobot> scummvm: [status: fail] [recipes/apple/cores-ios9-generic] LOG: http://p.0bl.net/86231 Last good build: N/A
