### PR TITLE
(3DS) Use ctr-legacy build container

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -54,7 +54,7 @@ include:
 
   # Nintendo 3DS
   - project: 'libretro-infrastructure/ci-templates'
-    file: '/ctr-static.yml'
+    file: '/ctr-legacy-static.yml'
 
   # Nintendo Switch
   - project: 'libretro-infrastructure/ci-templates'
@@ -158,7 +158,7 @@ libretro-build-wiiu:
 # Nintendo 3DS
 libretro-build-ctr:
   extends:
-    - .libretro-ctr-static-retroarch-master
+    - .libretro-ctr-legacy-static-retroarch-master
     - .core-defs
 
 # Nintendo Switch


### PR DESCRIPTION
It turns out that the 3DS core is incompatible with the latest devkitpro. This PR therefore updates the `.gitlab-ci.yml` file to make use of the legacy ctr build container, such that the 3DS core is compiled using the old toolchain (from before the build infrastructure upgrade).