### PR TITLE
libretro: cross compile fixes

### DIFF
--- a/backends/platform/libretro/build/Makefile
+++ b/backends/platform/libretro/build/Makefile
@@ -66,9 +66,9 @@ else
 endif
 endif
 
-LD        = $(CXX)
-AR        = ar cru
-RANLIB    = ranlib
+LD        ?= $(CXX)
+AR        ?= ar cru
+RANLIB    ?= ranlib
 
 ifeq ($(platform), unix)
    TARGET  := $(TARGET_NAME)_libretro.so

--- a/backends/platform/libretro/libretro_os.cpp
+++ b/backends/platform/libretro/libretro_os.cpp
@@ -673,7 +673,7 @@ class OSystem_RETRO : public EventsBaseBackend, public PaletteManager {
 					if (time_remaining > elapsed_time)
 					{
 						time_remaining = time_remaining - elapsed_time;
-						retro_sleep(1);
+						usleep(1000);
 					}
 					else
 					{
@@ -690,7 +690,7 @@ class OSystem_RETRO : public EventsBaseBackend, public PaletteManager {
 				// Use accurate method...
 				while(getMillis() < start_time + msecs)
 				{
-					retro_sleep(1);
+					usleep(1000);
 					retroCheckThread();
 					// Have to handle the timer manager here, since some engines
 					// (e.g. dreamweb) sit in a delayMillis() loop waiting for a


### PR DESCRIPTION
- fixes https://github.com/libretro/scummvm/issues/183 credits to @mrfixit2001 
- Makefile: only set LD, AR, RANLIB if not set before